### PR TITLE
 Replace deprecated animateItemPlacement and update Compose BOM

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -12,7 +12,7 @@ activity = "1.10.1"
 fragment = "1.8.6"
 lifecycle = "2.8.7"
 navigation = "2.8.9"
-composeBom = "2025.03.01"
+composeBom = "2025.04.01"
 
 # Testing
 junit = "4.13.2"

--- a/library/src/main/java/narek/dallakyan/dragging/component/DraggableItem.kt
+++ b/library/src/main/java/narek/dallakyan/dragging/component/DraggableItem.kt
@@ -34,7 +34,7 @@ fun LazyItemScope.DraggableItem(
     draggableState,
     key,
     modifier,
-    Modifier.animateItemPlacement(),
+    Modifier.animateItem(),
     orientationLocked,
     index,
     content

--- a/library/src/main/java/narek/dallakyan/dragging/extention/ModifierDragExt.kt
+++ b/library/src/main/java/narek/dallakyan/dragging/extention/ModifierDragExt.kt
@@ -3,52 +3,68 @@ package narek.dallakyan.dragging.extention
 import androidx.compose.foundation.gestures.awaitFirstDown
 import androidx.compose.foundation.gestures.forEachGesture
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.pointer.PointerInputChange
+import androidx.compose.ui.input.pointer.PointerInputScope
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.util.fastFirstOrNull
 import narek.dallakyan.dragging.model.StartDrag
 import narek.dallakyan.dragging.state.DraggableState
 
 
-fun Modifier.draggable(
-    state: DraggableState<*>,
-) = then(Modifier.pointerInput(Unit) {
-    forEachGesture {
-        val dragStart = state.interactions.receive()
-        val down = awaitPointerEventScope {
-            currentEvent.changes.fastFirstOrNull { it.id == dragStart.id }
-        }
-        if (down != null && state.onDragStart(
-                down.position.x.toInt(),
-                down.position.y.toInt()
-            )
-        ) {
-            dragStart.offset?.apply {
-                state.onDrag(x.toInt(), y.toInt())
-            }
-            detectDrag(
-                down.id,
-                onDragEnd = {
-                    state.onDragCanceled()
-                },
-                onDragCancel = {
-                    state.onDragCanceled()
-                },
-                onDrag = { change, dragAmount ->
-                    change.consume()
-                    state.onDrag(dragAmount.x.toInt(), dragAmount.y.toInt())
-                }
-            )
-        }
-    }
-}).then(
-    Modifier.pointerInput(true) {
-        forEachGesture {
-            val down = awaitPointerEventScope {
-                awaitFirstDown(requireUnconsumed = false)
-            }
-            awaitLongPressOrCancellation(down)?.also {
-                state.interactions.trySend(StartDrag(down.id))
-            }
-        }
-    }
+fun Modifier.draggable(state: DraggableState<*>) = then(
+    dragGestureHandler(state)
+).then(
+    longPressDragStarter(state)
 )
+
+private fun dragGestureHandler(state: DraggableState<*>): Modifier = Modifier.pointerInput(Unit) {
+    forEachGesture {
+        handleDragGesture(state)
+    }
+}
+
+private suspend fun PointerInputScope.handleDragGesture(state: DraggableState<*>) {
+    val dragStart = state.interactions.receive()
+    val down = awaitPointerEventScope {
+        currentEvent.changes.fastFirstOrNull { it.id == dragStart.id }
+    }
+
+    if (down != null && state.onDragStart(down.position.x.toInt(), down.position.y.toInt())) {
+        processDragMovement(state, dragStart, down)
+    }
+}
+
+private suspend fun PointerInputScope.processDragMovement(
+    state: DraggableState<*>,
+    dragStart: StartDrag,
+    down: PointerInputChange
+) {
+    dragStart.offset?.let {
+        state.onDrag(it.x.toInt(), it.y.toInt())
+    }
+
+    detectDrag(
+        down.id,
+        onDragEnd = { state.onDragCanceled() },
+        onDragCancel = { state.onDragCanceled() },
+        onDrag = { change, dragAmount ->
+            change.consume()
+            state.onDrag(dragAmount.x.toInt(), dragAmount.y.toInt())
+        }
+    )
+}
+
+private fun longPressDragStarter(state: DraggableState<*>): Modifier = Modifier.pointerInput(true) {
+    forEachGesture {
+        handleLongPressForDrag(state)
+    }
+}
+
+private suspend fun PointerInputScope.handleLongPressForDrag(state: DraggableState<*>) {
+    val down = awaitPointerEventScope {
+        awaitFirstDown(requireUnconsumed = false)
+    }
+    awaitLongPressOrCancellation(down)?.let {
+        state.interactions.trySend(StartDrag(down.id))
+    }
+}


### PR DESCRIPTION
This PR includes the following changes:

Fixed Deprecation Warning:
Replaced animateItemPlacement (deprecated) with animateItem to prevent potential crashes.
This change is necessary because the old API was removed in the latest Compose BOM update.

Refactored Draggable Logic:
Split the draggable modifier into smaller, more maintainable components (dragGestureHandler and longPressDragStarter).

Updated Dependencies:
Upgraded Compose BOM to 2025.04.01 to stay compatible with the latest changes.